### PR TITLE
Reduce gap and add border to badge images

### DIFF
--- a/credit.html
+++ b/credit.html
@@ -68,7 +68,11 @@
             display: flex;
             flex-direction: row;
             align-items: center; /* Aligns items vertically in the center */
-            gap: 10px; /* Optional: Adds space between badges */
+            gap: 2px; /* Optional: Adds space between badges */
+        }
+
+        .badge-container img {
+            border: 2px solid #f3f4f6;
         }
 
         .github-badge-container {
@@ -76,15 +80,19 @@
             justify-content: center; /* Horizontally centers the content */
         }
 
+        .github-badge-container img {
+            border: 2px solid #f3f4f6;
+        }
+
         body.dark .badge-container img {
             border: 2px solid white;
         }
 
-        body.dark .github-badge-container img{
+        body.dark .github-badge-container img {
             border: 2px solid white;
         }
 
-        body.dark img{
+        body.dark img {
             filter: brightness(80%);
         }
 
@@ -142,15 +150,15 @@
             </div>
             <p>Front-end web developer</p>
             <p>웹사이트 디자인 및 프로그래밍을 담당했습니다.</p>
-            <div class="badge-container" style="margin-bottom: 5px;">
+            <div class="badge-container" style="margin-bottom: 2px;">
                 <img src="https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white"
                      alt="HTML5">
-                <img src="https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E"
-                     alt="JavaScript">
-            </div>
-            <div class="badge-container">
                 <img src="https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white"
                      alt="CSS3">
+            </div>
+            <div class="badge-container">
+                <img src="https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E"
+                     alt="JavaScript">
             </div>
         </div>
     </div>


### PR DESCRIPTION
The CSS style for "badge-container" and "github-badge-container" has been updated. Gap between badges has been reduced and a border was added to the images for better visual separation. Additionally, the organization of badges was changed, where CSS3 badge is now before JavaScript, and badge-container margin bottom was reduced from 5px to 2px for better content fit.