### PR TITLE
Modify 'credit.html' CSS for dark mode image brightness

### DIFF
--- a/credit.html
+++ b/credit.html
@@ -132,7 +132,7 @@
             border: 2px solid white;
         }
 
-        body.dark img {
+        body.dark .credit-section img {
             filter: brightness(80%);
         }
 


### PR DESCRIPTION
Refined the CSS selector in 'credit.html'. Previously, all images in the dark mode had their brightness adjusted to 80%, which was causing inconsistencies in the styling. Now, only images in the '.credit-section' have their brightness adjusted when in dark mode. It improves the website's aesthetics and maintains a consistent design in dark mode.